### PR TITLE
Refactor platform-specific parts and add stub

### DIFF
--- a/lib/i2c.ex
+++ b/lib/i2c.ex
@@ -121,7 +121,7 @@ defmodule Circuits.I2C do
   """
   @spec detect_devices(reference() | binary) :: [integer] | {:error, term}
   def detect_devices(ref) when is_reference(ref) do
-    Enum.reject(0..127, &(read_device(ref, &1, 1) == {:error, :read_failed}))
+    Enum.filter(0..127, &device_present?(ref, &1))
   end
 
   def detect_devices(dev_name) when is_binary(dev_name) do
@@ -133,6 +133,13 @@ defmodule Circuits.I2C do
 
       error ->
         error
+    end
+  end
+
+  defp device_present?(i2c, address) do
+    case read_device(i2c, address, 1) do
+      {:ok, _} -> true
+      _ -> false
     end
   end
 end

--- a/src/hal_i2cdev.c
+++ b/src/hal_i2cdev.c
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2018 Frank Hunleth, Mark Sebald
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * I2C NIF implementation.
+ */
+
+#include "i2c_nif.h"
+#include "linux/i2c-dev.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int hal_i2c_open(const char *device)
+{
+    char devpath[32]="/dev/";
+
+    strncat(devpath, device, sizeof(devpath) - 1);
+    return open(devpath, O_RDWR);
+}
+
+void hal_i2c_close(int fd)
+{
+    close(fd);
+}
+
+int hal_i2c_transfer(int fd,
+                     unsigned int addr,
+                     const uint8_t *to_write, size_t to_write_len,
+                     uint8_t *to_read, size_t to_read_len)
+{
+    struct i2c_rdwr_ioctl_data data;
+    struct i2c_msg msgs[2];
+
+    msgs[0].addr = addr;
+    msgs[0].flags = 0;
+    msgs[0].len = to_write_len;
+    msgs[0].buf = (uint8_t *) to_write;
+
+    msgs[1].addr = addr;
+    msgs[1].flags = I2C_M_RD;
+    msgs[1].len = to_read_len;
+    msgs[1].buf = (uint8_t *) to_read;
+
+    if (to_write_len != 0)
+        data.msgs = &msgs[0];
+    else
+        data.msgs = &msgs[1];
+
+    data.nmsgs = (to_write_len != 0 && to_read_len != 0) ? 2 : 1;
+
+    return ioctl(fd, I2C_RDWR, &data);
+}
+

--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2018 Frank Hunleth, Mark Sebald
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * I2C NIF implementation.
+ */
+
+#include "i2c_nif.h"
+#include <string.h>
+
+int hal_i2c_open(const char *device)
+{
+    return 0;
+}
+
+void hal_i2c_close(int fd)
+{
+}
+
+int hal_i2c_transfer(int fd,
+                     unsigned int addr,
+                     const uint8_t *to_write, size_t to_write_len,
+                     uint8_t *to_read, size_t to_read_len)
+{
+    if (to_read_len > 0)
+        memset(to_read, 0, to_read_len);
+
+    return 0;
+}

--- a/src/i2c_nif.h
+++ b/src/i2c_nif.h
@@ -1,21 +1,10 @@
 #ifndef I2C_NIF_H
 #define I2C_NIF_H
 
-
-#include "linux/i2c-dev.h"
-#include "erl_nif.h"
-
+#include <erl_nif.h>
 #include <err.h>
-#include <stdbool.h>
-#include <stdio.h>
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-#include <fcntl.h>
-#include <sys/ioctl.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
+#include <stdio.h>
 
 //#define DEBUG
 
@@ -35,18 +24,42 @@
 
 #define I2C_BUFFER_MAX 8192
 
-// I2C NIF Resource.
-struct I2cNifRes {
-    int fd;
-    unsigned int addr;
-};
+/**
+ * Open an I2C device
+ *
+ * @param device the name of the I2C device
+ *
+ * @return <0 on error or a handle on success
+ */
+int hal_i2c_open(const char *device);
 
+/**
+ * Free resources associated with an I2C device
+ */
+void hal_i2c_close(int fd);
 
-// I2C NIF Private data
-struct I2cNifPriv {
-    ErlNifResourceType *i2c_nif_res_type;
-    ERL_NIF_TERM atom_ok;
-    ERL_NIF_TERM atom_error;
-};
+/**
+ * I2C combined write/read operation
+ *
+ * This function can be used to individually read or write
+ * bytes across the bus. Additionally, a write and read
+ * operation can be combined into one transaction. This is
+ * useful for communicating with register-based devices that
+ * support setting the current register via the first one or
+ * two bytes written.
+ *
+ * @param   fd            The I2C device file descriptor
+ * @param   addr          The device address
+ * @param   to_write      Optional write buffer
+ * @param   to_write_len  Write buffer length
+ * @param   to_read       Optional read buffer
+ * @param   to_read_len   Read buffer length
+ *
+ * @return  <0 for failure
+ */
+int hal_i2c_transfer(int fd,
+                     unsigned int addr,
+                     const uint8_t *to_write, size_t to_write_len,
+                     uint8_t *to_read, size_t to_read_len);
 
 #endif // I2C_NIF_H


### PR DESCRIPTION
This makes it possible to compile and "run" on OSX for test purposes.
The stub is currently minimal and HAL API will likely need additions if
non-Linux platforms are ever supported.

WIP Note: I haven't tested on Linux or Nerves. Once this PR gets to a good place, I'd like to do something similar on the other platforms. For GPIO, it will open up supporting non-Raspberry Pi platforms. 

While I was refactoring, I made a couple changes that should be reviewed:

1. On I2C errors, I'm returning the errno value rather than a generic "access denied", "write failed" etc. 
2. I added a call to close() when close is called. I assume that got accidentally dropped at some point.