### PR TITLE
Improve error message when opening unknown bus

### DIFF
--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -18,6 +18,7 @@
 
 #include "i2c_nif.h"
 #include <string.h>
+#include <errno.h>
 
 ERL_NIF_TERM hal_info(ErlNifEnv *env)
 {
@@ -28,7 +29,13 @@ ERL_NIF_TERM hal_info(ErlNifEnv *env)
 
 int hal_i2c_open(const char *device)
 {
-    return 0;
+    if (strcmp(device, "i2c-0") == 0) {
+        /* "Success" */
+        return 0;
+    } else {
+        errno = ENOENT;
+        return -1;
+    }
 }
 
 void hal_i2c_close(int fd)

--- a/src/i2c_nif.c
+++ b/src/i2c_nif.c
@@ -92,6 +92,10 @@ static ERL_NIF_TERM enif_make_errno_error(ErlNifEnv *env)
         reason = priv->atom_nak;
         break;
 #endif
+    case ENOENT:
+        reason = enif_make_atom(env, "bus_not_found");
+        break;
+
     default:
         // strerror isn't usually that helpful, so if these
         // errors happen, please report or update this code

--- a/test/circuits_i2c_test.exs
+++ b/test/circuits_i2c_test.exs
@@ -1,10 +1,22 @@
 defmodule CircuitsI2cTest do
   use ExUnit.Case
 
+  alias Circuits.I2C
+
   test "info returns a map" do
-    info = Circuits.I2C.info()
+    info = I2C.info()
 
     assert is_map(info)
     assert Map.has_key?(info, :name)
+  end
+
+  test "bus_names returns a list" do
+    names = I2C.bus_names()
+
+    assert is_list(names)
+  end
+
+  test "error when opening unknown bus" do
+    assert {:error, :bus_not_found} == I2C.open("bogus")
   end
 end


### PR DESCRIPTION
It now says something about the bus not being found.

Fixes #37