### PR TITLE
Refactor doc generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run: mix deps.get
       - run: mix format --check-formatted
       - run: mix compile
-      - run: mix docs
+      - run: MIX_ENV=docs mix docs
       - run: mix hex.build
       - run: mix test
       - run: mdl --style .circleci/md-style.rb *.md

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,15 @@
 defmodule Circuits.I2C.MixProject do
   use Mix.Project
 
+  @version "0.3.4"
+
   {:ok, system_version} = Version.parse(System.version())
   @elixir_version {system_version.major, system_version.minor, system_version.patch}
 
   def project do
     [
       app: :circuits_i2c,
-      version: "0.3.4",
+      version: @version,
       elixir: "~> 1.4",
       description: description(),
       package: package(),
@@ -15,7 +17,7 @@ defmodule Circuits.I2C.MixProject do
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],
-      docs: [extras: ["README.md", "PORTING.md"], main: "readme"],
+      docs: docs(),
       aliases: [docs: ["docs", &copy_images/1], format: [&format_c/1, "format"]],
       start_permanent: Mix.env() == :prod,
       build_embedded: true,
@@ -51,7 +53,7 @@ defmodule Circuits.I2C.MixProject do
 
   defp deps(elixir_version) when elixir_version >= {1, 7, 0} do
     [
-      {:ex_doc, "~> 0.11", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.11", only: :docs, runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false}
       | deps()
     ]
@@ -62,6 +64,15 @@ defmodule Circuits.I2C.MixProject do
   defp deps() do
     [
       {:elixir_make, "~> 0.5", runtime: false}
+    ]
+  end
+
+  defp docs do
+    [
+      extras: ["README.md", "PORTING.md"],
+      main: "readme",
+      source_ref: "v#{@version}",
+      source_url: "https://github.com/elixir-circuits/circuits_i2c"
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.6", "78e97d9c0ff1b5521dd68041193891aebebce52fc3b93463c0a6806874557d7d", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
-  "elixir_make": {:hex, :elixir_make, "0.5.2", "96a28c79f5b8d34879cd95ebc04d2a0d678cfbbd3e74c43cb63a76adf0ee8054", [:mix], [], "hexpm"},
-  "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.6.0", "38349f3e29aff4864352084fc736fa7fa0f2995a819a737554f7ebd28b85aaab", [:mix], [], "hexpm"},
+  "erlex": {:hex, :erlex, "0.2.2", "cb0e6878fdf86dc63509eaf2233a71fa73fc383c8362c8ff8e8b6f0c2bb7017c", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
This adds a link back to the source code from the docs and prevents ex_doc from being compiled in normal development.