### PR TITLE
Restrict addresses polled by detect_devices

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,6 @@ install_system_deps: &install_system_deps
       apt update
       apt install -y unzip
 
-install_mdl: &install_mdl
-  run:
-    name: Install Markdown Lint
-    command: |
-      apt install -y ruby
-      gem install mdl
-
 defaults: &defaults
   working_directory: ~/repo
 
@@ -43,7 +36,6 @@ jobs:
     steps:
       - checkout
       - <<: *install_system_deps
-      - <<: *install_mdl
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - restore_cache:
@@ -55,7 +47,6 @@ jobs:
       - run: MIX_ENV=docs mix docs
       - run: mix hex.build
       - run: mix test
-      - run: mdl --style .circleci/md-style.rb *.md
       - run: mix dialyzer --halt-exit-status
       - save_cache:
           key: v1-mix-cache-{{ checksum "mix.lock" }}

--- a/Makefile
+++ b/Makefile
@@ -66,13 +66,10 @@ $(BUILD)/%.o: src/%.c
 $(NIF): $(OBJ)
 	$(CC) -o $@ $(ERL_LDFLAGS) $(LDFLAGS) $^
 
-$(PREFIX):
-	mkdir -p $@
-
-$(BUILD):
+$(PREFIX) $(BUILD):
 	mkdir -p $@
 
 clean:
-	$(RM) $(NIF) $(BUILD)/*.o
+	$(RM) $(NIF) $(OBJ)
 
 .PHONY: all clean calling_from_make install

--- a/lib/i2c.ex
+++ b/lib/i2c.ex
@@ -187,7 +187,7 @@ defmodule Circuits.I2C do
   """
   @spec detect_devices(bus() | binary()) :: [address()] | {:error, term()}
   def detect_devices(i2c_bus) when is_reference(i2c_bus) do
-    Enum.filter(0..127, &device_present?(i2c_bus, &1))
+    Enum.filter(0x03..0x77, &device_present?(i2c_bus, &1))
   end
 
   def detect_devices(bus_name) when is_binary(bus_name) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,6 +2,7 @@ defmodule Circuits.I2C.MixProject do
   use Mix.Project
 
   @version "0.3.4"
+  @source_url "https://github.com/elixir-circuits/circuits_i2c"
 
   {:ok, system_version} = Version.parse(System.version())
   @elixir_version {system_version.major, system_version.minor, system_version.patch}
@@ -13,7 +14,7 @@ defmodule Circuits.I2C.MixProject do
       elixir: "~> 1.4",
       description: description(),
       package: package(),
-      source_url: "https://github.com/elixir-circuits/circuits_i2c",
+      source_url: @source_url,
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],
@@ -44,10 +45,11 @@ defmodule Circuits.I2C.MixProject do
         "README.md",
         "PORTING.md",
         "LICENSE",
+        "CHANGELOG.md",
         "Makefile"
       ],
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/elixir-circuits/circuits_i2c"}
+      links: %{"GitHub" => @source_url}
     }
   end
 
@@ -72,7 +74,7 @@ defmodule Circuits.I2C.MixProject do
       extras: ["README.md", "PORTING.md"],
       main: "readme",
       source_ref: "v#{@version}",
-      source_url: "https://github.com/elixir-circuits/circuits_i2c"
+      source_url: @source_url
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
-  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.6", "78e97d9c0ff1b5521dd68041193891aebebce52fc3b93463c0a6806874557d7d", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.7", "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix], [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.2", "3aa0bd23bc4c61cf2f1e5d752d1bb470560a6f8539974f767a38923bb20e1d7f", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.6.0", "38349f3e29aff4864352084fc736fa7fa0f2995a819a737554f7ebd28b85aaab", [:mix], [], "hexpm"},
-  "erlex": {:hex, :erlex, "0.2.2", "cb0e6878fdf86dc63509eaf2233a71fa73fc383c8362c8ff8e8b6f0c2bb7017c", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "erlex": {:hex, :erlex, "0.2.5", "e51132f2f472e13d606d808f0574508eeea2030d487fc002b46ad97e738b0510", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
The `i2cdetect` utility only polls 0x03 to 0x77 when detecting devices. It
seems reasonable to limit detection to those addresses especially since a
report was made today that `i2cdetect` worked and
`Circuits.I2C.detect_devices/1` caused an I2C bus hang. This appeared to be
due to a microcontroller not being happy, but it seems safer to limit the
range going forward especially since pretty much all devices are in the
reduced range anyway.