### PR TITLE
Fix link error when building with musl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ ifeq ($(CROSSCOMPILE),)
 else
 # Crosscompiled build
 LDFLAGS += -fPIC -shared
+CFLAGS += -fPIC
 endif
 
 # Set Erlang-specific compile and linker flags


### PR DESCRIPTION
This fixes the following linker error:

```
.../x86_64-unknown-linux-musl/bin/ld: obj/hal_i2cdev.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
```