### PR TITLE
Show hex value for detected devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Once an I2C bus is available, try detecting devices on it:
 iex> Circuits.I2C.detect_devices()
 Circuits.I2C.detect_devices
 Devices on I2C bus "i2c-1":
- * 64
- * 112
+ * 64  (0x40)
+ * 112 (0x70)
 
 2 devices detected on 1 I2C buses
 ```

--- a/lib/i2c.ex
+++ b/lib/i2c.ex
@@ -223,7 +223,7 @@ defmodule Circuits.I2C do
 
     devices = detect_devices(bus_name)
 
-    Enum.each(devices, &IO.puts(" * #{&1}"))
+    Enum.each(devices, &IO.puts(" * #{&1}  (0x#{Integer.to_string(&1, 16)})"))
 
     IO.puts("")
 


### PR DESCRIPTION
Sometimes it's easier to cross reference with a datasheet if you can quickly see the detected devices in hex instead of decimal. This will add the output on the terminal in hex as well. 