### PR TITLE
CI: switch to hexpm images and add Elixir 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,9 @@
 version: 2
 
-install_elixir: &install_elixir
-  run:
-    name: Install Elixir
-    command: |
-      wget https://repo.hex.pm/builds/elixir/v$ELIXIR_VERSION.zip
-      unzip -d /usr/local/elixir v$ELIXIR_VERSION.zip
-      echo 'export PATH=/usr/local/elixir/bin:$PATH' >> $BASH_ENV
+defaults: &defaults
+  working_directory: ~/repo
+  environment:
+    LC_ALL: C.UTF-8
 
 install_hex_rebar: &install_hex_rebar
   run:
@@ -19,25 +16,17 @@ install_system_deps: &install_system_deps
   run:
     name: Install system dependencies
     command: |
-      apt update
-      apt install -y unzip
-
-defaults: &defaults
-  working_directory: ~/repo
+        apk add build-base linux-headers
 
 jobs:
-  build_elixir_1_10_otp_23:
+  build_elixir_1_11_otp_23:
     docker:
-      - image: erlang:23.0
-        environment:
-          ELIXIR_VERSION: 1.10.3-otp-23
-          LC_ALL: C.UTF-8
+      - image: hexpm/elixir:1.11.2-erlang-23.1.2-alpine-3.12.1
     <<: *defaults
     steps:
       - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
       - <<: *install_hex_rebar
+      - <<: *install_system_deps
       - restore_cache:
           keys:
             - v1-mix-cache-{{ checksum "mix.lock" }}
@@ -47,148 +36,80 @@ jobs:
       - run: mix docs
       - run: mix hex.build
       - run: mix test
-      - run: mix dialyzer --halt-exit-status
+      - run: mix dialyzer
       - save_cache:
           key: v1-mix-cache-{{ checksum "mix.lock" }}
           paths:
             - _build
             - deps
 
-  build_elixir_1_10_otp_22:
+  build_elixir_1_10_otp_23:
     docker:
-      - image: erlang:22.3
-        environment:
-          ELIXIR_VERSION: 1.10.2-otp-22
-          LC_ALL: C.UTF-8
+      - image: hexpm/elixir:1.10.4-erlang-23.1.2-alpine-3.12.1
     <<: *defaults
     steps:
       - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
       - <<: *install_hex_rebar
-      - restore_cache:
-          keys:
-            - v1-mix-cache-{{ checksum "mix.lock" }}
+      - <<: *install_system_deps
       - run: mix deps.get
-      - run: mix format --check-formatted
       - run: mix compile
-      - run: mix docs
-      - run: mix hex.build
       - run: mix test
-      - run: mix dialyzer --halt-exit-status
-      - save_cache:
-          key: v1-mix-cache-{{ checksum "mix.lock" }}
-          paths:
-            - _build
-            - deps
 
   build_elixir_1_9_otp_22:
     docker:
-      - image: erlang:22.2.8
-        environment:
-          ELIXIR_VERSION: 1.9.4-otp-22
-          LC_ALL: C.UTF-8
+      - image: hexpm/elixir:1.9.4-erlang-22.3.4.9-alpine-3.12.0
     <<: *defaults
     steps:
       - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
       - <<: *install_hex_rebar
+      - <<: *install_system_deps
       - run: mix deps.get
       - run: mix compile
       - run: mix test
 
   build_elixir_1_8_otp_22:
     docker:
-      - image: erlang:22.0
-        environment:
-          ELIXIR_VERSION: 1.8.2-otp-22
-          LC_ALL: C.UTF-8
+      - image: hexpm/elixir:1.8.2-erlang-22.3.4.9-alpine-3.12.0
     <<: *defaults
     steps:
       - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
       - <<: *install_hex_rebar
+      - <<: *install_system_deps
       - run: mix deps.get
       - run: mix compile
       - run: mix test
 
   build_elixir_1_7_otp_21:
     docker:
-      - image: erlang:21.3
-        environment:
-          ELIXIR_VERSION: 1.7.4-otp-21
-          LC_ALL: C.UTF-8
+      - image: hexpm/elixir:1.7.4-erlang-21.3.8.15-alpine-3.12.0
     <<: *defaults
     steps:
       - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
       - <<: *install_hex_rebar
+      - <<: *install_system_deps
       - run: mix deps.get
       - run: mix compile
       - run: mix test
 
   build_elixir_1_6_otp_20:
     docker:
-      - image: erlang:20.3.8
-        environment:
-          ELIXIR_VERSION: 1.6.6-otp-20
-          LC_ALL: C.UTF-8
+      - image: hexpm/elixir:1.6.6-erlang-20.3.8.23-alpine-3.12.0
     <<: *defaults
     steps:
       - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
       - <<: *install_hex_rebar
+      - <<: *install_system_deps
       - run: mix deps.get
       - run: mix compile
-      - run: mix test
-
-  build_elixir_1_5_otp_20:
-    docker:
-      - image: erlang:20.3.8
-        environment:
-          ELIXIR_VERSION: 1.5.3-otp-20
-          LC_ALL: C.UTF-8
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
-      - <<: *install_hex_rebar
-      - run: mix deps.get
-      - run: mix compile
-      - run: MIX_ENV=test mix compile
-      - run: mix test
-
-  build_elixir_1_4_otp_20:
-    docker:
-      - image: erlang:20.3.8
-        environment:
-          ELIXIR_VERSION: 1.4.5-otp-20
-          LC_ALL: C.UTF-8
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
-      - <<: *install_hex_rebar
-      - run: mix deps.get
-      - run: mix compile
-      - run: MIX_ENV=test mix compile
       - run: mix test
 
 workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_11_otp_23
       - build_elixir_1_10_otp_23
-      - build_elixir_1_10_otp_22
       - build_elixir_1_9_otp_22
       - build_elixir_1_8_otp_22
       - build_elixir_1_7_otp_21
       - build_elixir_1_6_otp_20
-      - build_elixir_1_5_otp_20
-      - build_elixir_1_4_otp_20


### PR DESCRIPTION
This also drops some old builds since it seems like they haven't been
seen in the wild for a long time.