### PR TITLE
I2C.discover/1

### DIFF
--- a/lib/i2c.ex
+++ b/lib/i2c.ex
@@ -242,7 +242,11 @@ defmodule Circuits.I2C do
   defp discover(bus_name, possible_devices) when is_binary(bus_name) do
     case open(bus_name) do
       {:ok, i2c_bus} -> 
-        results = Enum.filter(possible_devices, &device_present?(i2c_bus, &1))
+        results = 
+          possible_devices
+          |> Enum.filter(&device_present?(i2c_bus, &1))
+          |> Enum.map(&{bus_name, &1})
+          
         close(i2c_bus)
         results
       _ -> 


### PR DESCRIPTION
I2C sensors can usually be configured with a couple of potential address names. Commercial sensor breakout boards must choose, and they often choose differently. This pull requests allows a sensor library to discover the bus name and device address, making it easier to get started with genservers without specifying options. 