### PR TITLE
Squash #64, add optional detection function, add tests

### DIFF
--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -73,7 +73,7 @@ int hal_i2c_transfer(int fd,
     else if (fd == 1 && i2c_test_1_open_count > 0 && addr == 0x20) {
         // Address 0x20 exists on "i2c-test-1"
         if (to_read_len > 0)
-            memset(to_read, 0, to_read_len);
+            memset(to_read, 0xff, to_read_len);
         return 0;
     }
 


### PR DESCRIPTION
This PR builds off #64 to add an optional detection function and add unit tests. The detection function lets users do something device-specific like query an ID register.

@batate - I squashed and rebased your PR to the first commit in the PR. Yesterday I made it possible to have unit tests for simple things with Circuits.I2C so I went ahead and added unit tests for the `discover*` functions. That's in the second commit for this PR. I believe that I didn't do anything to break any of the use cases that you outlined in #64. Could you take a look when you get a chance?