### PR TITLE
CI: Elixir 1.12/OTP 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ install_system_deps: &install_system_deps
         apk add build-base linux-headers
 
 jobs:
-  build_elixir_1_11_otp_23:
+  build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.11.3-erlang-23.2.2-alpine-3.12.1
+      - image: hexpm/elixir:1.12.0-rc.1-erlang-24.0-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
@@ -33,7 +33,6 @@ jobs:
       - run: mix deps.get
       - run: mix format --check-formatted
       - run: mix deps.unlock --check-unused
-      - run: mix compile --warnings-as-errors
       - run: mix docs
       - run: mix hex.build
       - run: mix test
@@ -44,6 +43,17 @@ jobs:
             - _build
             - deps
 
+  build_elixir_1_11_otp_23:
+    docker:
+      - image: hexpm/elixir:1.11.3-erlang-23.2.2-alpine-3.12.1
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix test
+
   build_elixir_1_10_otp_23:
     docker:
       - image: hexpm/elixir:1.10.4-erlang-23.1.2-alpine-3.12.1
@@ -53,7 +63,6 @@ jobs:
       - <<: *install_hex_rebar
       - <<: *install_system_deps
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
   build_elixir_1_9_otp_22:
@@ -65,7 +74,6 @@ jobs:
       - <<: *install_hex_rebar
       - <<: *install_system_deps
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
   build_elixir_1_8_otp_22:
@@ -77,7 +85,6 @@ jobs:
       - <<: *install_hex_rebar
       - <<: *install_system_deps
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
   build_elixir_1_7_otp_21:
@@ -89,7 +96,6 @@ jobs:
       - <<: *install_hex_rebar
       - <<: *install_system_deps
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
   build_elixir_1_6_otp_20:
@@ -101,13 +107,13 @@ jobs:
       - <<: *install_hex_rebar
       - <<: *install_system_deps
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
 workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23
       - build_elixir_1_10_otp_23
       - build_elixir_1_9_otp_22

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,6 @@
+# Always warning as errors
+if Version.match?(System.version(), "~> 1.10") do
+  Code.put_compiler_option(:warnings_as_errors, true)
+end
+
 ExUnit.start()


### PR DESCRIPTION
- Force warnings as errors in tests
- Add Elixir 1.12/OTP 24 build to Circle config

I referenced https://github.com/nerves-networking/vintage_net/pull/285  as an example.