### PR TITLE
v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.0 - 10-20-2021
+
+This release only changes the version number. No code has changed.
+
 ## v0.3.9
 
 This release only has doc and build output cleanup. No code has changed.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Circuits.I2C.MixProject do
   use Mix.Project
 
-  @version "0.3.9"
+  @version "1.0.0"
   @source_url "https://github.com/elixir-circuits/circuits_i2c"
 
   {:ok, system_version} = Version.parse(System.version())


### PR DESCRIPTION
The API has been pretty stable for years, so it seems like it's time for 1.0.0.
