### PR TITLE
Fix `format_c` to reference `c_src` directory

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -79,7 +79,7 @@ defmodule Circuits.I2C.MixProject do
         Mix.Shell.IO.info("Install astyle to format C code.")
 
       astyle ->
-        System.cmd(astyle, ["-n", "src/*.c"], into: IO.stream(:stdio, :line))
+        System.cmd(astyle, ["-n", "c_src/*.c"], into: IO.stream(:stdio, :line))
     end
   end
 


### PR DESCRIPTION
`src` was changed to `c_src`, but this formatting helper was missed so `astyle` would never run