### PR TITLE
Detect some addresses by using 0-length writes

### DIFF
--- a/lib/i2c.ex
+++ b/lib/i2c.ex
@@ -331,11 +331,12 @@ defmodule Circuits.I2C do
   some devices to actually do something.
   """
   @spec device_present?(bus(), address()) :: boolean()
+  def device_present?(i2c, address) when address in 0x30..0x37 or address in 0x50..0x5F do
+    match?({:ok, _}, read(i2c, address, 1))
+  end
+
   def device_present?(i2c, address) do
-    case read(i2c, address, 1) do
-      {:ok, _} -> true
-      _ -> false
-    end
+    :ok == write(i2c, address, <<>>)
   end
 
   @doc """


### PR DESCRIPTION
This is how the i2c-tools package detects devices, and it actually is
able to detect at least one more device than the original read method.
The i2c-tools comments warn that 0-byte writes are known to corrupt some
EEPROMs and the single byte reads are known to confuse write-only
devices. This copies the heuristic of using reads on the common EEPROM
addresses.
