### PR TITLE
Detect zero-byte write and adjust device detection

### DIFF
--- a/lib/i2c/i2c_nif.ex
+++ b/lib/i2c/i2c_nif.ex
@@ -10,6 +10,7 @@ defmodule Circuits.I2C.Nif do
   end
 
   def open(_device), do: :erlang.nif_error(:nif_not_loaded)
+  def flags(_ref), do: :erlang.nif_error(:nif_not_loaded)
   def read(_ref, _address, _count, _retries), do: :erlang.nif_error(:nif_not_loaded)
   def write(_ref, _address, _data, _retries), do: :erlang.nif_error(:nif_not_loaded)
 

--- a/test/i2c/i2c_nif_test.exs
+++ b/test/i2c/i2c_nif_test.exs
@@ -24,6 +24,12 @@ defmodule Circuits.I2CNifTest do
     end
   end
 
+  test "flags/1" do
+    {:ok, i2c} = Nif.open("i2c-test-0")
+    assert Nif.flags(i2c) == []
+    Nif.close(i2c)
+  end
+
   test "unloading NIF" do
     # The theory here is that there shouldn't be a crash if this is reloaded a
     # few times.


### PR DESCRIPTION
This fixes an issue where an I2C controller doesn't support zero byte
writes and then fails to detect on some I2C addresses.
