### PR TITLE
Defer loading the NIF until opening an I2C bus

### DIFF
--- a/lib/i2c/i2c_nif.ex
+++ b/lib/i2c/i2c_nif.ex
@@ -1,15 +1,17 @@
 defmodule Circuits.I2C.Nif do
-  @on_load {:load_nif, 0}
-  @compile {:autoload, false}
-
   @moduledoc false
 
-  def load_nif() do
+  defp load_nif() do
     nif_binary = Application.app_dir(:circuits_i2c, "priv/i2c_nif")
     :erlang.load_nif(to_charlist(nif_binary), 0)
   end
 
-  def open(_device), do: :erlang.nif_error(:nif_not_loaded)
+  def open(device) do
+    with :ok <- load_nif() do
+      apply(__MODULE__, :open, [device])
+    end
+  end
+
   def flags(_ref), do: :erlang.nif_error(:nif_not_loaded)
   def read(_ref, _address, _count, _retries), do: :erlang.nif_error(:nif_not_loaded)
   def write(_ref, _address, _data, _retries), do: :erlang.nif_error(:nif_not_loaded)
@@ -18,5 +20,9 @@ defmodule Circuits.I2C.Nif do
     do: :erlang.nif_error(:nif_not_loaded)
 
   def close(_ref), do: :erlang.nif_error(:nif_not_loaded)
-  def info(), do: :erlang.nif_error(:nif_not_loaded)
+
+  def info() do
+    :ok = load_nif()
+    apply(__MODULE__, :info, [])
+  end
 end


### PR DESCRIPTION
This change moves the NIF load from the time at which the module is
loaded to the time when a I2C actually is used.

The primary motivation for doing this is to defer native code crashes
from happening at load time to the time of first use. Load time is
harder to debug and sometimes its not clear which NIF caused the crash.

The calls to `apply` get around some complexity with ignoring Dialyzer
warnings. Dialyzer can't figure out that the recursive looking call
actually invokes the NIF code.
