### PR TITLE
Add `Circuits.I2C.bus()` spec back

### DIFF
--- a/lib/i2c.ex
+++ b/lib/i2c.ex
@@ -35,6 +35,11 @@ defmodule Circuits.I2C do
 
   @type opt() :: {:retries, non_neg_integer()}
 
+  @typedoc """
+  Connection to a real or virtual I2C controller
+  """
+  @type bus() :: Bus.t()
+
   defmacrop unwrap_or_raise(call) do
     quote do
       case unquote(call) do


### PR DESCRIPTION
This was present in v1.0 but moved to `Circuits.I2C.Bus.t()` in v2.0 which causes some errors when migrating.

For convenience, this adds the spec back to the top level `Circuits.I2C` that referenves the new spec

![image](https://github.com/elixir-circuits/circuits_i2c/assets/11321326/7435fe1c-27c4-49ea-a235-5d70775b63bd)
