### PR TITLE
Remove deferred loading of NIF

### DIFF
--- a/lib/i2c/i2c_nif.ex
+++ b/lib/i2c/i2c_nif.ex
@@ -1,21 +1,14 @@
 defmodule Circuits.I2C.Nif do
   @moduledoc false
 
-  defp load_nif_and_apply(fun, args) do
-    nif_binary = Application.app_dir(:circuits_i2c, "priv/i2c_nif")
+  @on_load {:load_nif, 0}
+  @compile {:autoload, false}
 
-    # Optimistically load the NIF. Handle the possible race.
-    case :erlang.load_nif(to_charlist(nif_binary), 0) do
-      :ok -> apply(__MODULE__, fun, args)
-      {:error, {:reload, _}} -> apply(__MODULE__, fun, args)
-      error -> error
-    end
+  def load_nif() do
+    :erlang.load_nif(:code.priv_dir(:circuits_i2c) ++ ~c"/i2c_nif", 0)
   end
 
-  def open(device) do
-    load_nif_and_apply(:open, [device])
-  end
-
+  def open(_device), do: :erlang.nif_error(:nif_not_loaded)
   def read(_ref, _address, _count, _retries), do: :erlang.nif_error(:nif_not_loaded)
   def write(_ref, _address, _data, _retries), do: :erlang.nif_error(:nif_not_loaded)
 
@@ -23,8 +16,5 @@ defmodule Circuits.I2C.Nif do
     do: :erlang.nif_error(:nif_not_loaded)
 
   def close(_ref), do: :erlang.nif_error(:nif_not_loaded)
-
-  def info() do
-    load_nif_and_apply(:info, [])
-  end
+  def info(), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/test/circuits_i2c_test.exs
+++ b/test/circuits_i2c_test.exs
@@ -84,20 +84,4 @@ defmodule Circuits.I2CTest do
     assert info.backend == Circuits.I2C.I2CDev
     assert info.test?
   end
-
-  test "racing to load the NIF" do
-    # Make sure the NIF isn't loaded
-    _ = :code.delete(Circuits.I2C.Nif)
-    _ = :code.purge(Circuits.I2C.Nif)
-
-    # Try to hit the race by having 32 processes race to load the NIF
-    tasks =
-      for _ <- 0..31 do
-        Task.async(fn ->
-          _ = Circuits.I2C.info()
-        end)
-      end
-
-    Enum.each(tasks, &Task.await/1)
-  end
 end


### PR DESCRIPTION
It was possible to crash the BEAM by loading a completely trimmed down
shared library with multiple processes. This converts the NIF loader
back to the traditional `@on_load` way that's serialized by the code
loader. The benefits of delaying the load time are less now that the
shared library has been tested quite a bit.
