### PR TITLE
Improve target detection for building i2c_dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -90,8 +90,16 @@ defmodule Circuits.I2C.MixProject do
     end
   end
 
-  # Assume Nerves for a default
-  defp default_backend(_env, _not_host), do: Circuits.I2C.I2CDev
+  # MIX_TARGET set to something besides host
+  defp default_backend(env, _not_host) do
+    # If CROSSCOMPILE is set, then the Makefile will use the crosscompiler and
+    # assume a Linux/Nerves build If not, then the NIF will be build for the
+    # host, so use the default host backend
+    case System.fetch_env("CROSSCOMPILE") do
+      {:ok, _} -> Circuits.I2C.I2CDev
+      :error -> default_backend(env, :host)
+    end
+  end
 
   defp set_make_env(_args) do
     # Since user configuration hasn't been loaded into the application


### PR DESCRIPTION
It turns out that people sometimes have MIX_TARGET set when they're not
compiling for Nerves. On MacOS which doesn't support i2c_dev, this
causes the following error:

```
==> circuits_i2c
"**** CIRCUITS_I2C_BACKEND set to [normal] ****"
Makefile:44: *** Circuits.I2C Linux i2c-dev backend is not supported on non-Linux platforms. Review circuits_i2c backend configuration or report an issue if improperly detected..  Stop.
could not compile dependency :circuits_i2c, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile circuits_i2c --force", update it with "mix deps.update circuits_i2c" or clean it with "mix deps.clean circuits_i2c"
```

This is pretty confusing. This change makes the Nerves detection smarter
by first checking the MIX_TARGET and then checking if crosscompilation
environment variables are actually set. If not, the host compiler will
be used, so use the default for host builds.
