### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Circuits.I2C
 
 [![Hex version](https://img.shields.io/hexpm/v/circuits_i2c.svg "Hex version")](https://hex.pm/packages/circuits_i2c)
-[![API docs](https://img.shields.io/hexpm/v/circuits_i2c.svg?label=hexdocs "API docs")](https://hexdocs.pm/circuits_i2c/Circuits.I2C.html)
+[![API docs](https://img.shields.io/hexpm/v/circuits_i2c.svg?label=hexdocs "API docs")](https://circuits-i2c.hexdocs.pm/Circuits.I2C.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/elixir-circuits/circuits_i2c/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/elixir-circuits/circuits_i2c/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/elixir-circuits/circuits_i2c)](https://api.reuse.software/info/github.com/elixir-circuits/circuits_i2c)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://circuits-i2c.hexdocs.pm/Circuits.I2C.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>